### PR TITLE
Removed the scroll bar appearing at the bottom of the page #19

### DIFF
--- a/resources/css/landingpage.css
+++ b/resources/css/landingpage.css
@@ -3,6 +3,7 @@ body {
     margin: 0px;
     margin-top: 3px;
     width: 100%;
+    overflow-x: hidden;
 }
 
 #rectangle1 {


### PR DESCRIPTION
Closes #19 

Type of Change
Removed the scroll bar appearing at the bottom of the page

New Feature

- [ ]  New Feature
- [X]  Bug Fix
- [ ]  Code Refactor
- [ ]  Documentation Update

Implementation Details
Removed the scroll bar at the bottom with the help of CSS `overflow-x` property

Demo image
![image](https://github.com/user-attachments/assets/b6bcd039-e008-42a5-833a-2472a7ad2b86)
